### PR TITLE
Improve dependency resolution performance

### DIFF
--- a/Sources/NugetHelper/NuGetClientHelper.cs
+++ b/Sources/NugetHelper/NuGetClientHelper.cs
@@ -581,8 +581,13 @@ namespace NuGetClientHelper
                     resolveDependencyLevels--;
                     foreach (var dependency in dependencyInfo.Dependencies)
                     {
-                        var knownPackage = installedPackages.Where((x) => x.Identity.Id == dependency.Id).FirstOrDefault();
-                        if (knownPackage == null || !dependency.VersionRange.Satisfies(knownPackage.Identity.VersionRange.MinVersion))
+                        var knownPackageIdentification = 
+                            installedPackages.Where((x) => x.Identity.Id == dependency.Id)
+                                             .Select(x => x.Identity).FirstOrDefault()
+                            ?? availablePackages.Where((x) => x.Id == dependency.Id)
+                                                .Select(x => new NuGetPackageIdentity(x.Id, x.Version.ToString())).FirstOrDefault();
+
+                        if (knownPackageIdentification == null || !dependency.VersionRange.Satisfies(knownPackageIdentification.VersionRange.MinVersion))
                         {
                             await GetPackageDependencyInfo(resolveDependencyLevels,
                             new PackageIdentity(dependency.Id, dependency.VersionRange.MinVersion),


### PR DESCRIPTION
Avoid looking for a dependency if it's installed or already known.
This might lead the resolution of a different dependency-version respect to the specified one in the NuSpec.
The CheckPackagesConsistency will highlight this deficit.